### PR TITLE
Heatmap stroke selection

### DIFF
--- a/src/heatmap/AHeatMapCanvasRenderer.ts
+++ b/src/heatmap/AHeatMapCanvasRenderer.ts
@@ -47,20 +47,26 @@ export abstract class AHeatMapCanvasRenderer {
       return;
     }
 
-    ctx.scale(canvas.width / dim[1], canvas.height / dim[0]);
-    selected.forEach((cell) => {
-      if (this.options.mode === 'sm') {
+
+    if (this.options.mode === 'sm') {
+      ctx.scale(canvas.width / dim[1], canvas.height / dim[0]);
+      selected.forEach((cell) => {
         cell.product((indices) => {
           const [i, j] = indices;
           ctx.fillRect(j, i, 1, 1);
         }, dim);
-      } else {
+      });
+    } else {
+      const cw = canvas.width / dim[1];
+      const ch = canvas.height / dim[0];
+      selected.forEach((cell) => {
         cell.product((indices) => {
           const [i, j] = indices;
-          ctx.strokeRect(j, i, 1, 1);
+          ctx.strokeRect(j * cw, i * ch, cw, ch);
         }, dim);
-      }
-    });
+      });
+    }
+
     ctx.restore();
 
   }

--- a/src/heatmap/AHeatMapCanvasRenderer.ts
+++ b/src/heatmap/AHeatMapCanvasRenderer.ts
@@ -35,6 +35,8 @@ export abstract class AHeatMapCanvasRenderer {
     ctx.save();
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.fillStyle = 'orange';
+    ctx.strokeStyle = 'orange';
+
     if (selected.length === 0) {
       ctx.restore();
       return;
@@ -47,10 +49,17 @@ export abstract class AHeatMapCanvasRenderer {
 
     ctx.scale(canvas.width / dim[1], canvas.height / dim[0]);
     selected.forEach((cell) => {
-      cell.product((indices) => {
-        const [i, j] = indices;
-        ctx.fillRect(j, i, 1, 1);
-      }, dim);
+      if (this.options.mode === 'sm') {
+        cell.product((indices) => {
+          const [i, j] = indices;
+          ctx.fillRect(j, i, 1, 1);
+        }, dim);
+      } else {
+        cell.product((indices) => {
+          const [i, j] = indices;
+          ctx.strokeRect(j, i, 1, 1);
+        }, dim);
+      }
     });
     ctx.restore();
 

--- a/src/heatmap/HeatMap.ts
+++ b/src/heatmap/HeatMap.ts
@@ -74,7 +74,8 @@ export default class HeatMap extends AVisInstance implements IVisInstance {
     scale: [1, 1],
     rotate: 0,
     labels: ESelectOption.NONE,
-    missingColor: '#d400c2'
+    missingColor: '#d400c2',
+    mode: 'sm'
   };
 
   constructor(public data: IHeatMapAbleMatrix, public parent: Element, options: IHeatMapOptions = {}) {

--- a/src/heatmap/HeatMapDOMRenderer.ts
+++ b/src/heatmap/HeatMapDOMRenderer.ts
@@ -78,7 +78,11 @@ export default class HeatMapDOMRenderer implements IHeatMapRenderer {
       }
       selected.forEach((cell) => {
         cell.product((indices) => {
-          $g.select(`g:nth-child(${indices[0] + 1})`).select(`rect:nth-child(${indices[1] + 1})`).classed('phovea-select-' + type, true);
+          const cell = <SVGRectElement>$g.select(`rect[y="${indices[0]}"][x="${indices[1]}"]`).classed('phovea-select-' + type, true).node();
+          // push parent to front
+          cell.parentElement.appendChild(cell);
+          // push parent to front
+          cell.parentElement.parentElement.appendChild(cell.parentElement);
         }, data.dim);
       });
     };

--- a/src/heatmap/HeatMapDOMRenderer.ts
+++ b/src/heatmap/HeatMapDOMRenderer.ts
@@ -28,18 +28,20 @@ export default class HeatMapDOMRenderer implements IHeatMapRenderer {
 
   recolor($node: d3.Selection<any>, data: IHeatMapAbleMatrix, color: IScale, scale: number[]) {
     this.color = color;
-    $node.select('svg').selectAll('rect').attr('fill', (d) => isMissing(d) ? this.options.missingColor : color(d));
+    this.redraw($node, scale);
   }
 
   redraw($node: d3.Selection<any>, scale: number[]) {
-    $node.select('svg').selectAll('rect').attr('fill', (d) => isMissing(d) ? this.options.missingColor : this.color(d));
+    $node.select('svg').selectAll('rect')
+      .attr('fill', (d) => isMissing(d) ? this.options.missingColor : this.color(d))
+      .classed('missing', isMissing);
   }
 
   build(data: IHeatMapAbleMatrix, $parent: d3.Selection<any>, scale: [number, number], c: IScale, onReady: () => void) {
     const dims = data.dim, that = this;
     const width = dims[1], height = dims[0];
 
-    const $node = $parent.append('div').attr('class', 'phovea-heatmap');
+    const $node = $parent.append('div').attr('class', 'phovea-heatmap ' + this.options.mode);
     const $svg = $node.append('svg').attr({
       width: width * scale[0],
       height: height * scale[1]
@@ -58,6 +60,7 @@ export default class HeatMapDOMRenderer implements IHeatMapRenderer {
           y: i,
           fill: (d) => isMissing(d) ? that.options.missingColor : c(d)
         });
+        $colsEnter.classed('missing', isMissing);
         if (that.selectAble !== ESelectOption.NONE) {
           $colsEnter.on('click', (d, j) => {
             data.selectProduct([cell(i, j)], toSelectOperation(<MouseEvent>d3.event));

--- a/src/heatmap/internal.ts
+++ b/src/heatmap/internal.ts
@@ -71,6 +71,11 @@ export interface ICommonHeatMapOptions extends IVisInstanceOptions {
    * @default magenta
    */
   missingColor?: string;
+
+  /**
+   * defines the rendering mode, e.g. influencing how the selection is drawn
+   */
+  mode?: 'lg'|'sm';
 }
 
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -132,13 +132,27 @@ div.phovea-heatmap {
 
 
 .phovea-heatmap {
-  // highlight selection for svg heatmap
-  rect {
-    &.phovea-select-selected {
-      fill: $select-color;
+  &.lg {
+    // highlight selection for svg heatmap
+    rect {
+      &.phovea-select-selected {
+        stroke: $select-color;
+        stroke-width: 1;
+      }
+      &.phovea-select-hovered {
+        stroke: $hover-color;
+        stroke-width: 1;
+      }
     }
-    &.phovea-select-hovered {
-      fill: $hover-color;
+  }
+  &.sm {
+    rect {
+      &.phovea-select-selected {
+        fill: $select-color;
+      }
+      &.phovea-select-hovered {
+        fill: $hover-color;
+      }
     }
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -137,11 +137,9 @@ div.phovea-heatmap {
     rect {
       &.phovea-select-selected {
         stroke: $select-color;
-        stroke-width: 1;
       }
       &.phovea-select-hovered {
         stroke: $hover-color;
-        stroke-width: 1;
       }
     }
   }


### PR DESCRIPTION
support `mode` flag (sm default vs lg) in heatmap that influences how selections are rendered. 

sm -> fill
lg -> stroke

svg
![2017-06-06 16_07_36-taggle](https://cloud.githubusercontent.com/assets/4129778/26833367/85e77256-4ad2-11e7-825a-2c6bb81333e2.png)

canvas
![2017-06-06 16_08_06-program manager](https://cloud.githubusercontent.com/assets/4129778/26833366/859f4634-4ad2-11e7-9dba-44d59162bd01.png)