### PR TITLE
Use POST method for heatmap loading if URL is too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ node_js:
 - 6
 addons:
   firefox: 49.0.1
+services:
+  - xvfb
 before_install:
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 script: npm run dist
 notifications:

--- a/src/heatmap/HeatMapImageRenderer.ts
+++ b/src/heatmap/HeatMapImageRenderer.ts
@@ -10,8 +10,9 @@ import {IScale, ICommonHeatMapOptions} from './internal';
 import {IHeatMapRenderer, ESelectOption} from './IHeatMapRenderer';
 import AHeatMapCanvasRenderer from './AHeatMapCanvasRenderer';
 import {IHeatMapAbleMatrix} from './HeatMap';
-import {sendAPI, api2absURL, encodeParams} from 'phovea_core/src/ajax';
+import {sendAPI, encodeParams} from 'phovea_core/src/ajax';
 import parseRange from 'phovea_core/src/range/parser';
+import {prepareHeatmapUrlParameter} from 'phovea_core/src/matrix/loader';
 
 
 function ensureHex(color: string) {
@@ -139,7 +140,7 @@ export default class HeatMapImageRenderer extends AHeatMapCanvasRenderer impleme
     // persist to get range and create range object again
     // TODO: make range property on matrix public
     const range = parseRange(data.persist().range);
-    const params = prepareParameter(range, args);
+    const params = prepareHeatmapUrlParameter(range, args);
     const url = `/dataset/matrix/${data.desc.id}/data`;
 
     const encoded = encodeParams(params);
@@ -157,25 +158,4 @@ export default class HeatMapImageRenderer extends AHeatMapCanvasRenderer impleme
 
     return $root;
   }
-}
-
-function prepareParameter(range: Range, options: IHeatMapUrlOptions) {
-  const args: any = {
-    format: options.format || 'png',
-    range: range.toString()
-  };
-  if (options.transpose === true) {
-    args.format_transpose = true;
-  }
-  if (options.range) {
-    args.format_min = options.range[0];
-    args.format_max = options.range[1];
-  }
-  if (options.palette) {
-    args.format_palette = options.palette.toString();
-  }
-  if (options.missing) {
-    args.format_missing = options.missing;
-  }
-  return args;
 }

--- a/src/heatmap/HeatMapImageRenderer.ts
+++ b/src/heatmap/HeatMapImageRenderer.ts
@@ -10,7 +10,7 @@ import {IScale, ICommonHeatMapOptions} from './internal';
 import {IHeatMapRenderer, ESelectOption} from './IHeatMapRenderer';
 import AHeatMapCanvasRenderer from './AHeatMapCanvasRenderer';
 import {IHeatMapAbleMatrix} from './HeatMap';
-import {sendAPI, encodeParams} from 'phovea_core/src/ajax';
+import {sendAPI, encodeParams, MAX_URL_LENGTH} from 'phovea_core/src/ajax';
 import parseRange from 'phovea_core/src/range/parser';
 import {prepareHeatmapUrlParameter} from 'phovea_core/src/matrix/loader';
 
@@ -20,9 +20,6 @@ function ensureHex(color: string) {
   const toHex = (d: number) => ('00' + d.toString(16)).slice(-2);
   return `#${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
 }
-
-// maximum number of characters of a valid URL
-const MAX_URL_LENGTH = 4096;
 
 export default class HeatMapImageRenderer extends AHeatMapCanvasRenderer implements IHeatMapRenderer {
   private image: HTMLImageElement;

--- a/src/heatmap/HeatMapImageRenderer.ts
+++ b/src/heatmap/HeatMapImageRenderer.ts
@@ -20,7 +20,8 @@ function ensureHex(color: string) {
   return `#${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
 }
 
-const TOO_LONG_URL = 4096;
+// maximum number of characters of a valid URL
+const MAX_URL_LENGTH = 4096;
 
 export default class HeatMapImageRenderer extends AHeatMapCanvasRenderer implements IHeatMapRenderer {
   private image: HTMLImageElement;
@@ -142,7 +143,7 @@ export default class HeatMapImageRenderer extends AHeatMapCanvasRenderer impleme
     const url = `/dataset/matrix/${data.desc.id}/data`;
 
     const encoded = encodeParams(params);
-    if (encoded && (url.length + encoded.length > TOO_LONG_URL)) {
+    if (encoded && (url.length + encoded.length >= MAX_URL_LENGTH)) {
       // use post instead
       sendAPI(url, params, 'POST', 'blob').then((image) => {
         const imageURL = window.URL.createObjectURL(image);


### PR DESCRIPTION
Fixes #69
Requires https://github.com/phovea/phovea_server/pull/83, https://github.com/phovea/phovea_core/pull/149

If the range parameter is too large (and results in a too long URL) the POST method is used to get the heatmap image. An URL is considered too long when it has more than 4096 characters.

![image](https://user-images.githubusercontent.com/52395160/64517630-012a2000-d2f1-11e9-88db-b0feeaf58d52.png)

![image](https://user-images.githubusercontent.com/52395160/64517695-21f27580-d2f1-11e9-8f73-dd5481ed2274.png)

The implementation is similar to [tdp_core data loading](https://github.com/datavisyn/tdp_core/blob/d8216da36070e7464b7273db72d3c59f852f0d91/src/rest.ts#L75-L90).
