### PR TITLE
Upgrade to Font Awesome v5 (Free)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "d3": "~3.5.17",
     "phovea_core": "github:phovea/phovea_core#develop",
-    "phovea_d3": "github:phovea/phovea_d3#dmoitzi/refactor_stylesheets_organiation_and_imports"
+    "phovea_d3": "github:phovea/phovea_d3#fontawesome-v5"
   },
   "devDependencies": {
     "@types/d3": "~3.5.36",


### PR DESCRIPTION
Currently, we are using Font Awesome v4, but should upgrade to Font Awesome v5 (Free).

See https://github.com/phovea/phovea_ui/issues/121